### PR TITLE
Add configurable margin offsets for PDF rendering

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -1,3 +1,5 @@
 [DEFAULT]
 Max.DPI = 1200
 Vibrance.Bump = False
+Margin.X = 0
+Margin.Y = 0

--- a/main.py
+++ b/main.py
@@ -92,6 +92,8 @@ def pdf_gen(p_dict, size):
     pages = canvas.Canvas(pdf_fp, pagesize=size)
     cols, rows = int(pw // w), int(ph // h)
     rx, ry = round((pw - (w * cols)) / 2), round((ph - (h * rows)) / 2)
+    rx += cfg.getint("Margin.X")
+    ry += cfg.getint("Margin.Y")
     total_cards = sum(img_dict.values())
     pbreak = cols * rows
     i = 0


### PR DESCRIPTION
Add `Margin.X` and `Margin.Y` options to `config.ini` to offset the card grid from its auto-centered position on the page.

Required for Epson EcoTank ET-8550 printer compatibility — the printer feed offset needs adjustment that the auto-centering doesn't account for.

**Changes:**
- `config.ini` — added `Margin.X = 0` and `Margin.Y = 0` defaults
- `main.py` — `pdf_gen()` now reads and applies the margin offsets to `rx`/`ry`

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)